### PR TITLE
chore!: renames lambda property to lambdaFunction

### DIFF
--- a/lib/namedQuery.ts
+++ b/lib/namedQuery.ts
@@ -43,7 +43,7 @@ export class NamedQuery extends Construct {
   /**
    * The lambda function that is created
    */
-  public readonly lambda: aws_lambda.IFunction;
+  public readonly lambdaFunction: aws_lambda.IFunction;
   /**
    * Name of the query
    */
@@ -60,7 +60,7 @@ export class NamedQuery extends Construct {
   constructor(scope: Construct, id: string, props: NamedQueryProps) {
     super(scope, id);
 
-    this.lambda = ensureLambda(this);
+    this.lambdaFunction = ensureLambda(this);
     this.name = props.name;
 
     const namedQueryProperties: NamedQueryProperties = {
@@ -85,7 +85,7 @@ export class NamedQuery extends Construct {
         .replace(/\s+/g, '-')
         .replace(/[a-z0-9_-]+/gi, '')}`,
       {
-        serviceToken: this.lambda.functionArn,
+        serviceToken: this.lambdaFunction.functionArn,
         resourceType: resourceType,
         properties: namedQueryProperties,
       },

--- a/lib/workGroup.ts
+++ b/lib/workGroup.ts
@@ -124,7 +124,7 @@ export class WorkGroup extends Construct implements ITaggable {
   /**
    * The lambda function that is created
    */
-  public readonly lambda: aws_lambda.IFunction;
+  public readonly lambdaFunction: aws_lambda.IFunction;
 
   /**
    * Name of the WorkGroup
@@ -166,7 +166,7 @@ export class WorkGroup extends Construct implements ITaggable {
     this.tags.setTag(createdByTag, ID);
 
     const stack = Stack.of(this);
-    this.lambda = ensureLambda(this);
+    this.lambdaFunction = ensureLambda(this);
     this.name = props.name;
 
     const workGroupProperties: WorkGroupProperties = {
@@ -198,7 +198,7 @@ export class WorkGroup extends Construct implements ITaggable {
       this,
       `Athena-WorkGroup-${this.name}`,
       {
-        serviceToken: this.lambda.functionArn,
+        serviceToken: this.lambdaFunction.functionArn,
         resourceType: resourceType,
         properties: workGroupProperties,
       },


### PR DESCRIPTION
Even though this never was a real problem to my knowledge, jsii always complained about the use of the keyword `lambda`:

> warning JSII5018: "lambda" is a reserved word in Python. Using this name may cause problems when generating language bindings. Consider a different name.

Therefore we now rename it to `lambdaFunction`.

This is a potential breaking change. If you used the exposed property `lambda` it needs to be changed to `lambdaFunction`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed a property related to lambda function usage for clarity in code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->